### PR TITLE
Fabric tests: Support peerDependencies for @types/react and @types/react-dom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ jspm_packages/
 .node_repl_history
 
 # Output of 'npm pack'
-# *.tgz
+*.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ jspm_packages/
 .node_repl_history
 
 # Output of 'npm pack'
-*.tgz
+# *.tgz
 
 # Yarn Integrity file
 .yarn-integrity

--- a/StoreTypeDefVersions.ps1
+++ b/StoreTypeDefVersions.ps1
@@ -1,0 +1,9 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -22,6 +22,15 @@
       "safeForSimultaneousRushProcesses": false,
       "enableParallelism": true,
       "ignoreMissingScript": false
+    },
+    {
+      "commandKind": "bulk",
+      "name": "update-react-types",
+      "summary": "Syncs @types/react and @types/react-dom with office-ui-fabric-react",
+      "description": "Syncs @types/react and @types/react-dom with office-ui-fabric-react.",
+      "safeForSimultaneousRushProcesses": false,
+      "enableParallelism": true,
+      "ignoreMissingScript": true
     }
   ],
   "parameters": []

--- a/common/config/rush/pnpmfile.js
+++ b/common/config/rush/pnpmfile.js
@@ -29,10 +29,10 @@ module.exports = {
  */
 function readPackage(packageJson, context) {
 
-  // // The karma types have a missing dependency on typings from the log4js package.
-  // if (packageJson.name === '@types/karma') {
-  //  context.log('Fixed up dependencies for @types/karma');
-  //  packageJson.dependencies['log4js'] = '0.6.38';
+  // Synchronize @types/react and @types/react-dom with office-ui-fabric-react
+  // if (packageJson.name.includes('office-ui-fabric-react-test')) {
+    // packageJson.dependencies['@types/react'] = process.env.TYPES_REACT_VERSION;
+    // packageJson.dependencies['@types/react-dom'] = process.env.TYPES_REACT_DOM_VERSION;
   // }
 
   return packageJson;

--- a/common/config/rush/pnpmfile.js
+++ b/common/config/rush/pnpmfile.js
@@ -29,10 +29,10 @@ module.exports = {
  */
 function readPackage(packageJson, context) {
 
-  // Synchronize @types/react and @types/react-dom with office-ui-fabric-react
-  // if (packageJson.name.includes('office-ui-fabric-react-test')) {
-    // packageJson.dependencies['@types/react'] = process.env.TYPES_REACT_VERSION;
-    // packageJson.dependencies['@types/react-dom'] = process.env.TYPES_REACT_DOM_VERSION;
+  // // The karma types have a missing dependency on typings from the log4js package.
+  // if (packageJson.name === '@types/karma') {
+  //  context.log('Fixed up dependencies for @types/karma');
+  //  packageJson.dependencies['log4js'] = '0.6.38';
   // }
 
   return packageJson;

--- a/tests/2.4/StoreTypeDefVersions.ps1
+++ b/tests/2.4/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/2.4/package.json
+++ b/tests/2.4/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/2.7/StoreTypeDefVersions.ps1
+++ b/tests/2.7/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/2.7/package.json
+++ b/tests/2.7/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/2.8/StoreTypeDefVersions.ps1
+++ b/tests/2.8/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/2.8/package.json
+++ b/tests/2.8/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/2.9/StoreTypeDefVersions.ps1
+++ b/tests/2.9/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/2.9/package.json
+++ b/tests/2.9/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/3.0/StoreTypeDefVersions.ps1
+++ b/tests/3.0/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/3.0/package.json
+++ b/tests/3.0/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/3.1/StoreTypeDefVersions.ps1
+++ b/tests/3.1/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/3.1/package.json
+++ b/tests/3.1/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/3.2/StoreTypeDefVersions.ps1
+++ b/tests/3.2/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/3.2/package.json
+++ b/tests/3.2/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/3.3/StoreTypeDefVersions.ps1
+++ b/tests/3.3/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/3.3/package.json
+++ b/tests/3.3/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/3.4/StoreTypeDefVersions.ps1
+++ b/tests/3.4/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/3.4/package.json
+++ b/tests/3.4/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },

--- a/tests/3.5/StoreTypeDefVersions.ps1
+++ b/tests/3.5/StoreTypeDefVersions.ps1
@@ -1,0 +1,10 @@
+[string]$fabric_relative_path = ".\node_modules\office-ui-fabric-react\package.json"
+
+$jsonData = Get-Content -Raw -Path $fabric_relative_path | ConvertFrom-Json;
+
+# early return if neither available
+[string]$reactTypesVersion = $jsonData.devDependencies."@types/react";
+[string]$reactDomTypesVersion = $jsonData.devDependencies."@types/react-dom";
+
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react@$reactTypesVersion --exact --make-consistent"
+Invoke-Expression "node ../../common/scripts/install-run-rush.js add -p @types/react-dom@$reactDomTypesVersion --exact --make-consistent"

--- a/tests/3.5/package.json
+++ b/tests/3.5/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
+    "update-react-types": "pwsh StoreTypeDefVersions.ps1",
     "install-fabric": "npm install --save --package-lock-only --no-package-lock office-ui-fabric-react",
     "test": "node ./node_modules/typescript/bin/tsc -p ./tsconfig.json"
   },


### PR DESCRIPTION
Fixes tests against Fabric 7 which bumped the `peerDependencies`: `@types/react` and `@types/react-dom`.

I'm working to consolidate the scripts required into ideally a single script prior to merge of this PR.